### PR TITLE
fix(bitable): 规范化复杂字段索引匹配

### DIFF
--- a/api/sheet.py
+++ b/api/sheet.py
@@ -99,7 +99,7 @@ API 端点（基础路径：https://open.feishu.cn/open-apis/sheets）：
 
 import logging
 import time
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional, Tuple, Union
 
 from .auth import FeishuAuth
 from .base import RetryableAPIClient
@@ -300,7 +300,7 @@ class SheetAPI:
 
     def identify_formula_columns(
         self, formula_data: List[List[Any]], headers: Optional[List[str]] = None
-    ) -> set:
+    ) -> set[Union[str, int]]:
         """
         识别包含公式的列
 
@@ -311,7 +311,7 @@ class SheetAPI:
         Returns:
             包含公式的列集合（列名或列索引）
         """
-        formula_cols = set()
+        formula_cols: set[Union[str, int]] = set()
 
         if not formula_data:
             return formula_cols
@@ -1315,7 +1315,9 @@ class SheetAPI:
                         if isinstance(detail["start_row"], int) and isinstance(
                             detail["end_row"], int
                         ):
-                            row_count = detail["end_row"] - detail["start_row"] + 1
+                            row_count: Union[int, str] = (
+                                detail["end_row"] - detail["start_row"] + 1
+                            )
                         else:
                             row_count = "未知"
                         self.logger.info(

--- a/core/config.py
+++ b/core/config.py
@@ -130,7 +130,9 @@ class SyncConfig:
     target_type: TargetType
 
     # Excel工作表选择
-    excel_sheet_name: Optional[Union[str, int]] = None  # 工作表名称或索引（0=第一个sheet）
+    excel_sheet_name: Optional[Union[str, int]] = (
+        None  # 工作表名称或索引（0=第一个sheet）
+    )
 
     # 多维表格配置（target_type=bitable时使用）
     app_token: Optional[str] = None

--- a/core/control.py
+++ b/core/control.py
@@ -106,7 +106,6 @@ from typing import Any, Callable, Optional, Union
 
 import requests  # type: ignore[import-untyped]
 
-
 # ============================================================================
 # 重试策略实现
 # ============================================================================
@@ -525,28 +524,28 @@ class GlobalRequestController:
             rate_limit_config = {"delay": 0.1}
 
         if rate_limit_type == "fixed_wait":
-            rate_config = FixedWaitRateConfig(
+            fixed_wait_config = FixedWaitRateConfig(
                 **{k: v for k, v in rate_limit_config.items() if k in ["delay"]}
             )
-            rate_limit_strategy = FixedWaitRateLimit(rate_config)
+            rate_limit_strategy = FixedWaitRateLimit(fixed_wait_config)
         elif rate_limit_type == "sliding_window":
-            rate_config = SlidingWindowRateConfig(
+            sliding_window_config = SlidingWindowRateConfig(
                 **{
                     k: v
                     for k, v in rate_limit_config.items()
                     if k in ["window_size", "max_requests"]
                 }
             )
-            rate_limit_strategy = SlidingWindowRateLimit(rate_config)
+            rate_limit_strategy = SlidingWindowRateLimit(sliding_window_config)
         elif rate_limit_type == "fixed_window":
-            rate_config = FixedWindowRateConfig(
+            fixed_window_config = FixedWindowRateConfig(
                 **{
                     k: v
                     for k, v in rate_limit_config.items()
                     if k in ["window_size", "max_requests"]
                 }
             )
-            rate_limit_strategy = FixedWindowRateLimit(rate_config)
+            rate_limit_strategy = FixedWindowRateLimit(fixed_window_config)
 
         # 创建控制器
         controller = RequestController(retry_strategy, rate_limit_strategy)

--- a/core/converter.py
+++ b/core/converter.py
@@ -225,7 +225,8 @@ class DataConverter:
                 return self._normalize_index_value(value.get("value"), nested_type)
 
             if "text" in value:
-                return str(value.get("text", ""))
+                text_value = str(value.get("text", ""))
+                return text_value if text_value.strip() else None
 
             if "link_record_ids" in value:
                 return self._normalize_index_value(
@@ -261,7 +262,9 @@ class DataConverter:
                 text_parts = []
                 for item in values:
                     if isinstance(item, dict) and "text" in item:
-                        text_parts.append(str(item.get("text", "")))
+                        text_value = str(item.get("text", ""))
+                        if text_value.strip():
+                            text_parts.append(text_value)
                     else:
                         item_value = self._normalize_index_value(item)
                         if item_value is not None:
@@ -919,11 +922,11 @@ class DataConverter:
         self, field_name: str, value, field_types: Optional[Dict[str, int]] = None
     ):
         """安全的字段值转换"""
-        if pd.isnull(value):
-            return None
-
         # 多维表格模式使用复杂转换
         if self.target_type == TargetType.BITABLE:
+            if self._is_empty_value(value):
+                return None
+
             # 如果没有字段类型信息，使用智能转换
             if field_types is None or field_name not in field_types:
                 return self.smart_convert_value(value)
@@ -948,6 +951,13 @@ class DataConverter:
                 self.conversion_stats["failed"] += 1
                 return None
         else:
+            if pd.api.types.is_scalar(value):
+                try:
+                    if pd.isnull(value):
+                        return None
+                except (TypeError, ValueError):
+                    pass
+
             # 电子表格模式使用简单转换
             return self.simple_convert_value(value)
 
@@ -1249,7 +1259,7 @@ class DataConverter:
 
     def convert_to_user_field(self, value):
         """转换为人员字段格式"""
-        if pd.isnull(value) or not value:
+        if self._is_empty_value(value):
             return None
 
         # 如果已经是正确的字典格式
@@ -1280,7 +1290,7 @@ class DataConverter:
 
     def convert_to_url_field(self, value):
         """转换为超链接字段格式"""
-        if pd.isnull(value) or not value:
+        if self._is_empty_value(value):
             return None
 
         # 如果已经是正确的字典格式
@@ -1299,7 +1309,7 @@ class DataConverter:
 
     def convert_to_attachment_field(self, value):
         """转换为附件字段格式"""
-        if pd.isnull(value) or not value:
+        if self._is_empty_value(value):
             return None
 
         # 如果已经是正确的字典格式
@@ -1322,7 +1332,7 @@ class DataConverter:
 
     def convert_to_link_field(self, value):
         """转换为关联字段格式"""
-        if pd.isnull(value) or not value:
+        if self._is_empty_value(value):
             return None
 
         # 如果已经是列表格式

--- a/core/converter.py
+++ b/core/converter.py
@@ -183,7 +183,9 @@ class DataConverter:
                 seconds = timestamp
             else:
                 return str(timestamp)
-            return dt.datetime.utcfromtimestamp(seconds).date().isoformat()
+            # Keep index normalization aligned with _force_to_timestamp(), which
+            # parses date strings as local wall-clock dates before writing them.
+            return dt.datetime.fromtimestamp(seconds).date().isoformat()
 
         if isinstance(value, str):
             str_val = value.strip()

--- a/core/converter.py
+++ b/core/converter.py
@@ -162,7 +162,7 @@ class DataConverter:
         return str(number)
 
     def _normalize_timestamp_index_value(self, value: Any) -> Optional[str]:
-        """规范化日期索引值为飞书日期字段使用的毫秒时间戳。"""
+        """规范化日期索引值，统一为按天比较的 ISO 日期字符串。"""
         if self._is_empty_value(value):
             return None
 
@@ -258,7 +258,17 @@ class DataConverter:
             if field_type == 1 or all(
                 isinstance(item, dict) and "text" in item for item in values
             ):
-                return "".join(str(item.get("text", "")) for item in values)
+                text_parts = []
+                for item in values:
+                    if isinstance(item, dict) and "text" in item:
+                        text_parts.append(str(item.get("text", "")))
+                    else:
+                        item_value = self._normalize_index_value(item)
+                        if item_value is not None:
+                            text_parts.append(item_value)
+                if not text_parts:
+                    return None
+                return "".join(text_parts)
 
             normalized_items = [
                 self._normalize_index_value(item, field_type) for item in values

--- a/core/converter.py
+++ b/core/converter.py
@@ -175,8 +175,8 @@ class DataConverter:
         if isinstance(value, dt.date):
             return value.isoformat()
 
-        if isinstance(value, numbers.Number) and not isinstance(value, bool):
-            timestamp = int(value)
+        if isinstance(value, numbers.Real) and not isinstance(value, bool):
+            timestamp = int(float(value))
             if timestamp > 2524608000:
                 seconds = timestamp / 1000
             elif timestamp > 946684800:

--- a/core/converter.py
+++ b/core/converter.py
@@ -78,9 +78,11 @@
 """
 
 import re
+import json
 import hashlib
 import logging
 import datetime as dt
+import numbers
 from typing import Any, Dict, List, Optional, TypedDict
 
 import pandas as pd
@@ -118,41 +120,195 @@ class DataConverter:
         """重置转换统计"""
         self.conversion_stats = {"success": 0, "failed": 0, "warnings": []}
 
+    def _is_empty_value(self, value: Any) -> bool:
+        """判断值是否为空，兼容 list/dict 等非标量对象。"""
+        if value is None:
+            return True
+
+        if isinstance(value, str):
+            return value.strip() == ""
+
+        if isinstance(value, dict):
+            if "value" in value:
+                return self._is_empty_value(value.get("value"))
+            return len(value) == 0
+
+        if isinstance(value, (list, tuple, set)):
+            return len(value) == 0 or all(self._is_empty_value(item) for item in value)
+
+        if pd.api.types.is_scalar(value):
+            try:
+                return bool(pd.isna(value))
+            except (TypeError, ValueError):
+                return False
+
+        return False
+
+    def _normalize_number_index_value(self, value: Any) -> Optional[str]:
+        """规范化数字索引值，避免 1 与 1.0 生成不同哈希。"""
+        if self._is_empty_value(value):
+            return None
+
+        if isinstance(value, bool):
+            return "1" if value else "0"
+
+        try:
+            number = float(str(value).strip().replace(",", ""))
+        except (TypeError, ValueError):
+            return str(value)
+
+        if number.is_integer():
+            return str(int(number))
+        return str(number)
+
+    def _normalize_timestamp_index_value(self, value: Any) -> Optional[str]:
+        """规范化日期索引值为飞书日期字段使用的毫秒时间戳。"""
+        if self._is_empty_value(value):
+            return None
+
+        if isinstance(value, pd.Timestamp):
+            value = value.to_pydatetime()
+
+        if isinstance(value, dt.datetime):
+            return value.date().isoformat()
+
+        if isinstance(value, dt.date):
+            return value.isoformat()
+
+        if isinstance(value, numbers.Number) and not isinstance(value, bool):
+            timestamp = int(value)
+            if timestamp > 2524608000:
+                seconds = timestamp / 1000
+            elif timestamp > 946684800:
+                seconds = timestamp
+            else:
+                return str(timestamp)
+            return dt.datetime.utcfromtimestamp(seconds).date().isoformat()
+
+        if isinstance(value, str):
+            str_val = value.strip()
+            if str_val.isdigit():
+                return self._normalize_timestamp_index_value(int(str_val))
+
+            for fmt in [
+                "%Y-%m-%d %H:%M:%S",
+                "%Y-%m-%d",
+                "%Y/%m/%d %H:%M:%S",
+                "%Y/%m/%d",
+                "%m/%d/%Y",
+                "%d/%m/%Y",
+                "%Y年%m月%d日",
+                "%m月%d日",
+                "%Y-%m-%d %H:%M",
+                "%Y/%m/%d %H:%M",
+            ]:
+                try:
+                    return dt.datetime.strptime(str_val, fmt).date().isoformat()
+                except ValueError:
+                    continue
+
+        timestamp = self._force_to_timestamp(value, "__index__")
+        if timestamp is None:
+            return None
+        return self._normalize_timestamp_index_value(timestamp)
+
+    def _normalize_index_value(
+        self, value: Any, field_type: Optional[int] = None
+    ) -> Optional[str]:
+        """将本地值和飞书返回值统一为可比较的索引字符串。"""
+        if self._is_empty_value(value):
+            return None
+
+        if isinstance(value, dict):
+            if "value" in value and "type" in value:
+                nested_type = value.get("type")
+                return self._normalize_index_value(value.get("value"), nested_type)
+
+            if "text" in value:
+                return str(value.get("text", ""))
+
+            if "link_record_ids" in value:
+                return self._normalize_index_value(
+                    value.get("link_record_ids"), field_type
+                )
+
+            if "id" in value:
+                return str(value.get("id"))
+
+            if "file_token" in value:
+                return str(value.get("file_token"))
+
+            normalized_dict = {
+                str(k): self._normalize_index_value(v) for k, v in value.items()
+            }
+            normalized_dict = {
+                k: v for k, v in normalized_dict.items() if v is not None
+            }
+            if not normalized_dict:
+                return None
+            return json.dumps(
+                normalized_dict,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+
+        if isinstance(value, (list, tuple, set)):
+            values = list(value)
+            if field_type == 1 or all(
+                isinstance(item, dict) and "text" in item for item in values
+            ):
+                return "".join(str(item.get("text", "")) for item in values)
+
+            normalized_items = [
+                self._normalize_index_value(item, field_type) for item in values
+            ]
+            normalized_items = [item for item in normalized_items if item is not None]
+            if not normalized_items:
+                return None
+            if len(normalized_items) == 1:
+                return normalized_items[0]
+            return json.dumps(
+                normalized_items, ensure_ascii=False, separators=(",", ":")
+            )
+
+        if field_type == 2:
+            return self._normalize_number_index_value(value)
+
+        if field_type == 5:
+            return self._normalize_timestamp_index_value(value)
+
+        if field_type == 7:
+            if isinstance(value, bool):
+                return "true" if value else "false"
+            converted = self._force_to_boolean(value, "__index__")
+            return "true" if converted else "false"
+
+        return str(value)
+
     def get_index_value_hash(
-        self, row: pd.Series, index_column: Optional[str]
+        self,
+        row: pd.Series,
+        index_column: Optional[str],
+        field_types: Optional[Dict[str, int]] = None,
     ) -> Optional[str]:
         """计算索引值的哈希，空值返回 None 避免误匹配"""
         if index_column and index_column in row:
             value = row[index_column]
-            # 非标量值（如 list/ndarray）先做空值判断，再哈希
-            if not pd.api.types.is_scalar(value):
-                try:
-                    if len(value) == 0:
-                        return None
-                except TypeError:
-                    pass
-
-                try:
-                    if all(
-                        pd.isna(item) or (isinstance(item, str) and not item.strip())
-                        for item in value
-                    ):
-                        return None
-                except Exception:
-                    pass
-
-                return hashlib.md5(str(value).encode("utf-8")).hexdigest()
-
-            if pd.isna(value):
+            field_type = field_types.get(index_column) if field_types else None
+            index_value = self._normalize_index_value(value, field_type)
+            if index_value is None:
                 return None
-
-            return hashlib.md5(str(value).encode("utf-8")).hexdigest()
+            return hashlib.md5(index_value.encode("utf-8")).hexdigest()
         return None
 
     # ========== 多维表格转换方法 ==========
 
     def build_record_index(
-        self, records: List[Dict[str, Any]], index_column: Optional[str]
+        self,
+        records: List[Dict[str, Any]],
+        index_column: Optional[str],
+        field_types: Optional[Dict[str, int]] = None,
     ) -> Dict[str, Dict[str, Any]]:
         """构建多维表格记录索引"""
         index: Dict[str, Dict[str, Any]] = {}
@@ -163,18 +319,10 @@ class DataConverter:
             fields = record.get("fields", {})
             if index_column in fields:
                 raw_value = fields[index_column]
-
-                # 处理富文本格式：[{'text': '内容', 'type': 'text'}]
-                if isinstance(raw_value, list) and len(raw_value) > 0:
-                    if isinstance(raw_value[0], dict) and "text" in raw_value[0]:
-                        index_value = raw_value[0]["text"]
-                    else:
-                        index_value = str(raw_value[0])
-                elif isinstance(raw_value, dict) and "text" in raw_value:
-                    index_value = raw_value["text"]
-                else:
-                    index_value = str(raw_value)
-
+                field_type = field_types.get(index_column) if field_types else None
+                index_value = self._normalize_index_value(raw_value, field_type)
+                if index_value is None:
+                    continue
                 index_hash = hashlib.md5(index_value.encode("utf-8")).hexdigest()
                 index[index_hash] = record
 
@@ -345,8 +493,6 @@ class DataConverter:
 
     def _is_timestamp_enhanced(self, s: str) -> tuple:
         """增强的时间戳检测"""
-        from datetime import datetime
-
         if not s.isdigit():
             return False, 0.0
 
@@ -798,7 +944,7 @@ class DataConverter:
     def _force_convert_to_feishu_type(self, value, field_name: str, field_type: int):
         """强制转换值为指定的飞书字段类型"""
         if field_type == 1:  # 文本字段 - 所有值都可以转换为文本
-            return str(value)
+            return self._normalize_index_value(value, field_type)
         elif field_type == 2:  # 数字字段 - 强制转换为数字
             return self._force_to_number(value, field_name)
         elif field_type == 3:  # 单选字段 - 转换为单个字符串
@@ -1376,7 +1522,7 @@ class DataConverter:
         for _, row in df.iterrows():
             fields = {}
             for k, v in row.to_dict().items():
-                if pd.notnull(v):
+                if not self._is_empty_value(v):
                     converted_value = self.convert_field_value_safe(
                         str(k), v, field_types
                     )

--- a/core/engine.py
+++ b/core/engine.py
@@ -83,7 +83,6 @@
 """
 
 import pandas as pd
-import time
 import logging
 import sys
 from datetime import datetime
@@ -735,7 +734,6 @@ class XTFSyncEngine:
             是否相等
         """
         import pandas as pd
-        import numpy as np
 
         # 都是空值
         if pd.isnull(val1) and pd.isnull(val2):
@@ -936,8 +934,9 @@ class XTFSyncEngine:
         existing_records = self.get_all_bitable_records(field_names=fetch_fields)
         self.logger.info(f"🔍 获取到现有记录数量: {len(existing_records)}")
 
+        field_types = self.get_field_types()
         existing_index = self.converter.build_record_index(
-            existing_records, self.config.index_column
+            existing_records, self.config.index_column, field_types
         )
         self.logger.info(f"🔍 构建索引成功，索引数量: {len(existing_index)}")
 
@@ -946,11 +945,12 @@ class XTFSyncEngine:
             for i, record in enumerate(existing_records[:3]):
                 fields = record.get("fields", {})
                 index_value = fields.get(self.config.index_column, "未找到")
-                self.logger.info(
-                    f"🔍 现有记录 {i+1} 索引列 '{self.config.index_column}' 值: '{index_value}'"
+                normalized_value = self.converter._normalize_index_value(
+                    index_value, field_types.get(self.config.index_column)
                 )
-
-        field_types = self.get_field_types()
+                self.logger.info(
+                    f"🔍 现有记录 {i + 1} 索引列 '{self.config.index_column}' 值: '{index_value}' -> 规范化: '{normalized_value}'"
+                )
 
         # 分类本地数据
         records_to_update = []
@@ -958,14 +958,14 @@ class XTFSyncEngine:
 
         for i, (_, row) in enumerate(df.iterrows()):
             index_hash = self.converter.get_index_value_hash(
-                row, self.config.index_column
+                row, self.config.index_column, field_types
             )
             index_value = row.get(self.config.index_column, "未找到")
 
             # 打印前几条记录的匹配信息用于调试
             if i < 3:
                 self.logger.info(
-                    f"🔍 新数据记录 {i+1} 索引列 '{self.config.index_column}' 值: '{index_value}' -> 哈希: {index_hash}"
+                    f"🔍 新数据记录 {i + 1} 索引列 '{self.config.index_column}' 值: '{index_value}' -> 哈希: {index_hash}"
                 )
                 self.logger.info(
                     f"🔍 哈希是否在现有索引中: {index_hash in existing_index if index_hash else False}"
@@ -974,7 +974,7 @@ class XTFSyncEngine:
             # 使用字段类型转换构建记录
             fields = {}
             for k, v in row.to_dict().items():
-                if pd.notnull(v):
+                if not self.converter._is_empty_value(v):
                     converted_value = self.converter.convert_field_value_safe(
                         str(k), v, field_types
                     )
@@ -1330,24 +1330,24 @@ class XTFSyncEngine:
         # 获取现有记录并建立索引（仅获取索引列，减少数据传输）
         fetch_fields = self._get_bitable_fetch_field_names(df, "incremental")
         existing_records = self.get_all_bitable_records(field_names=fetch_fields)
-        existing_index = self.converter.build_record_index(
-            existing_records, self.config.index_column
-        )
         field_types = self.get_field_types()
+        existing_index = self.converter.build_record_index(
+            existing_records, self.config.index_column, field_types
+        )
 
         # 筛选出需要新增的记录
         records_to_create = []
 
         for _, row in df.iterrows():
             index_hash = self.converter.get_index_value_hash(
-                row, self.config.index_column
+                row, self.config.index_column, field_types
             )
 
             if not index_hash or index_hash not in existing_index:
                 # 使用字段类型转换构建记录
                 fields = {}
                 for k, v in row.to_dict().items():
-                    if pd.notnull(v):
+                    if not self.converter._is_empty_value(v):
                         converted_value = self.converter.convert_field_value_safe(
                             str(k), v, field_types
                         )
@@ -1594,17 +1594,17 @@ class XTFSyncEngine:
         # 获取现有记录并建立索引（仅获取索引列，减少数据传输）
         fetch_fields = self._get_bitable_fetch_field_names(df, "overwrite")
         existing_records = self.get_all_bitable_records(field_names=fetch_fields)
-        existing_index = self.converter.build_record_index(
-            existing_records, self.config.index_column
-        )
         field_types = self.get_field_types()
+        existing_index = self.converter.build_record_index(
+            existing_records, self.config.index_column, field_types
+        )
 
         # 找出需要删除的记录
         record_ids_to_delete = []
 
         for _, row in df.iterrows():
             index_hash = self.converter.get_index_value_hash(
-                row, self.config.index_column
+                row, self.config.index_column, field_types
             )
             if index_hash and index_hash in existing_index:
                 existing_record = existing_index[index_hash]

--- a/core/engine.py
+++ b/core/engine.py
@@ -2128,7 +2128,10 @@ class XTFSyncEngine:
 
             for _, row in df.head(sample_size).iterrows():
                 for col_name, value in row.to_dict().items():
-                    if pd.notnull(value) and col_name in field_types:
+                    if (
+                        not self.converter._is_empty_value(value)
+                        and col_name in field_types
+                    ):
                         field_type = field_types[col_name]
                         # 简单的类型不匹配检测
                         if field_type == 2 and isinstance(

--- a/core/engine.py
+++ b/core/engine.py
@@ -514,6 +514,9 @@ class XTFSyncEngine:
             if not self.config.spreadsheet_token:
                 self.logger.error("电子表格的 spreadsheet_token 未配置")
                 return pd.DataFrame()
+            if not self.config.sheet_id:
+                self.logger.error("电子表格的 sheet_id 未配置")
+                return pd.DataFrame()
 
             if not (end_row and end_col):
                 return pd.DataFrame()
@@ -649,8 +652,11 @@ class XTFSyncEngine:
         else:
             # 转换为二维列表用于识别
             formula_data = [formula_df.columns.tolist()] + formula_df.values.tolist()
-            formula_columns = self.api.identify_formula_columns(
-                formula_data, headers=formula_df.columns.tolist()
+            formula_columns = set(
+                str(col)
+                for col in self.api.identify_formula_columns(
+                    formula_data, headers=formula_df.columns.tolist()
+                )
             )
 
         if formula_columns:
@@ -680,17 +686,20 @@ class XTFSyncEngine:
         if formula_columns is None:
             formula_columns = set()
 
-        diff_stats = {
-            "formula_columns": {},  # 公式列差异: {列名: 差异行数}
-            "data_columns": {},  # 数据列差异: {列名: 差异行数}
-            "error_columns": {},  # 异常列: {列名: 错误信息}
+        formula_diff: Dict[str, int] = {}
+        data_diff: Dict[str, int] = {}
+        error_diff: Dict[str, str] = {}
+        diff_stats: Dict[str, Any] = {
+            "formula_columns": formula_diff,  # 公式列差异: {列名: 差异行数}
+            "data_columns": data_diff,  # 数据列差异: {列名: 差异行数}
+            "error_columns": error_diff,  # 异常列: {列名: 错误信息}
             "total_rows": len(local_df),
         }
 
         # 遍历所有列
         for col in local_df.columns:
             if col not in remote_result_df.columns:
-                diff_stats["error_columns"][col] = "云端不存在此列"
+                error_diff[str(col)] = "云端不存在此列"
                 continue
 
             try:
@@ -713,12 +722,12 @@ class XTFSyncEngine:
                 # 记录差异
                 if diff_count > 0:
                     if col in formula_columns:
-                        diff_stats["formula_columns"][col] = diff_count
+                        formula_diff[str(col)] = diff_count
                     else:
-                        diff_stats["data_columns"][col] = diff_count
+                        data_diff[str(col)] = diff_count
 
             except Exception as e:
-                diff_stats["error_columns"][col] = str(e)
+                error_diff[str(col)] = str(e)
 
         return diff_stats
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -40,4 +40,5 @@ XTF 测试套件包
 作者: XTF Team
 版本: 1.7.3+
 """
+
 # XTF Test Suite

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -169,6 +169,17 @@ class TestIndexValueHash:
 
         assert plain_hash == rich_text_hash
 
+    def test_get_index_value_hash_text_list_matches_plain_text(self):
+        """测试文本字段中 list[str] 与普通文本生成相同索引哈希"""
+        converter = DataConverter(TargetType.BITABLE)
+        plain_row = pd.Series({"ID": "AB"})
+        text_list_row = pd.Series({"ID": ["A", "B"]})
+
+        plain_hash = converter.get_index_value_hash(plain_row, "ID", {"ID": 1})
+        text_list_hash = converter.get_index_value_hash(text_list_row, "ID", {"ID": 1})
+
+        assert plain_hash == text_list_hash
+
     def test_get_index_value_hash_date_string_matches_timestamp(self):
         """测试本地日期字符串和飞书日期时间戳生成相同索引哈希"""
         converter = DataConverter(TargetType.BITABLE)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -101,7 +101,7 @@ import pytest
 import pandas as pd
 import hashlib
 
-from core.config import TargetType, FieldTypeStrategy
+from core.config import TargetType
 from core.converter import DataConverter
 
 
@@ -156,6 +156,32 @@ class TestIndexValueHash:
         hash_value = converter.get_index_value_hash(row, "ID")
         assert hash_value is None
 
+    def test_get_index_value_hash_rich_text_matches_plain_text(self):
+        """测试本地普通文本和飞书富文本返回值生成相同索引哈希"""
+        converter = DataConverter(TargetType.BITABLE)
+        plain_row = pd.Series({"ID": "李宁少昊运动户外专卖店"})
+        rich_text_row = pd.Series(
+            {"ID": [{"text": "李宁少昊运动户外专卖店", "type": "text"}]}
+        )
+
+        plain_hash = converter.get_index_value_hash(plain_row, "ID", {"ID": 1})
+        rich_text_hash = converter.get_index_value_hash(rich_text_row, "ID", {"ID": 1})
+
+        assert plain_hash == rich_text_hash
+
+    def test_get_index_value_hash_date_string_matches_timestamp(self):
+        """测试本地日期字符串和飞书日期时间戳生成相同索引哈希"""
+        converter = DataConverter(TargetType.BITABLE)
+        date_row = pd.Series({"Date": "2026-03-03"})
+        timestamp_row = pd.Series({"Date": 1772496000000})
+
+        date_hash = converter.get_index_value_hash(date_row, "Date", {"Date": 5})
+        timestamp_hash = converter.get_index_value_hash(
+            timestamp_row, "Date", {"Date": 5}
+        )
+
+        assert date_hash == timestamp_hash
+
 
 class TestBuildRecordIndex:
     """记录索引构建测试"""
@@ -192,6 +218,59 @@ class TestBuildRecordIndex:
 
         hash_key = hashlib.md5("test_value".encode("utf-8")).hexdigest()
         assert hash_key in index
+
+    def test_build_record_index_date_type_matches_local_date_string(self):
+        """测试日期字段索引使用毫秒时间戳规范化匹配本地日期"""
+        converter = DataConverter(TargetType.BITABLE)
+        records = [
+            {
+                "record_id": "rec001",
+                "fields": {"Date": 1772496000000},
+            }
+        ]
+
+        index = converter.build_record_index(records, "Date", {"Date": 5})
+        local_hash = converter.get_index_value_hash(
+            pd.Series({"Date": "2026-03-03"}), "Date", {"Date": 5}
+        )
+
+        assert local_hash in index
+        assert index[local_hash]["record_id"] == "rec001"
+
+    def test_build_record_index_formula_wrapped_text_value(self):
+        """测试公式/查找引用包装的文本值可用于索引匹配"""
+        converter = DataConverter(TargetType.BITABLE)
+        records = [
+            {
+                "record_id": "rec001",
+                "fields": {
+                    "Status": {
+                        "type": 1,
+                        "value": [{"text": "整体", "type": "text"}],
+                    }
+                },
+            }
+        ]
+
+        index = converter.build_record_index(records, "Status")
+        local_hash = converter.get_index_value_hash(
+            pd.Series({"Status": "整体"}), "Status", {"Status": 1}
+        )
+
+        assert local_hash in index
+        assert index[local_hash]["record_id"] == "rec001"
+
+    def test_build_record_index_skips_empty_complex_values(self):
+        """测试空复杂字段不会进入索引，避免误匹配"""
+        converter = DataConverter(TargetType.BITABLE)
+        records = [
+            {"record_id": "rec001", "fields": {"ID": []}},
+            {"record_id": "rec002", "fields": {"ID": {"type": 1, "value": []}}},
+        ]
+
+        index = converter.build_record_index(records, "ID", {"ID": 1})
+
+        assert index == {}
 
 
 class TestTypeDetection:
@@ -577,6 +656,21 @@ class TestDfToRecords:
         assert len(records) == 5
         assert "fields" in records[0]
         assert "ID" in records[0]["fields"]
+
+    def test_df_to_records_preserves_complex_text_value(self):
+        """测试文本字段写入不会把飞书富文本结构转成 Python 字面量字符串"""
+        converter = DataConverter(TargetType.BITABLE)
+        df = pd.DataFrame(
+            {
+                "Name": [
+                    [{"text": "李宁少昊运动户外专卖店", "type": "text"}],
+                ]
+            }
+        )
+
+        records = converter.df_to_records(df, {"Name": 1})
+
+        assert records == [{"fields": {"Name": "李宁少昊运动户外专卖店"}}]
 
     def test_df_to_records_sheet_raises_error(self, sample_dataframe):
         """测试电子表格模式调用 df_to_records 抛出错误"""

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -97,9 +97,12 @@
 版本: 1.7.3+
 """
 
+import hashlib
+import os
+import time
+
 import pytest
 import pandas as pd
-import hashlib
 
 from core.config import TargetType
 from core.converter import DataConverter
@@ -201,6 +204,35 @@ class TestIndexValueHash:
         )
 
         assert date_hash == timestamp_hash
+
+    def test_get_index_value_hash_date_roundtrip_uses_local_timezone(self):
+        """测试本工具写出的本地日期时间戳读回后仍能匹配索引"""
+        if not hasattr(time, "tzset"):
+            pytest.skip("当前平台不支持 time.tzset")
+
+        old_tz = os.environ.get("TZ")
+        try:
+            os.environ["TZ"] = "Asia/Shanghai"
+            time.tzset()
+
+            converter = DataConverter(TargetType.BITABLE)
+            written_timestamp = converter._force_to_timestamp("2026-03-03", "Date")
+
+            date_hash = converter.get_index_value_hash(
+                pd.Series({"Date": "2026-03-03"}), "Date", {"Date": 5}
+            )
+            timestamp_hash = converter.get_index_value_hash(
+                pd.Series({"Date": written_timestamp}), "Date", {"Date": 5}
+            )
+
+            assert written_timestamp == 1772467200000
+            assert date_hash == timestamp_hash
+        finally:
+            if old_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = old_tz
+            time.tzset()
 
 
 class TestBuildRecordIndex:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -180,6 +180,15 @@ class TestIndexValueHash:
 
         assert plain_hash == text_list_hash
 
+    def test_get_index_value_hash_empty_rich_text_is_empty(self):
+        """测试空富文本不会生成空字符串哈希"""
+        converter = DataConverter(TargetType.BITABLE)
+        rich_text_row = pd.Series({"ID": [{"text": "", "type": "text"}]})
+
+        hash_value = converter.get_index_value_hash(rich_text_row, "ID", {"ID": 1})
+
+        assert hash_value is None
+
     def test_get_index_value_hash_date_string_matches_timestamp(self):
         """测试本地日期字符串和飞书日期时间戳生成相同索引哈希"""
         converter = DataConverter(TargetType.BITABLE)
@@ -522,6 +531,32 @@ class TestConvertFieldValueSafe:
         result = converter.convert_field_value_safe("test", "123", None)
         assert result == 123  # 智能识别为数字
 
+    def test_convert_multi_segment_text_value(self):
+        """测试多段富文本写入文本字段时不会触发 pandas 空值判断异常"""
+        converter = DataConverter(TargetType.BITABLE)
+        value = [
+            {"text": "李宁少昊", "type": "text"},
+            {"text": "运动户外专卖店", "type": "text"},
+        ]
+
+        result = converter.convert_field_value_safe("Name", value, {"Name": 1})
+
+        assert result == "李宁少昊运动户外专卖店"
+
+    def test_convert_multi_value_complex_fields(self):
+        """测试多个复杂字段值写入时不会触发 pandas 空值判断异常"""
+        converter = DataConverter(TargetType.BITABLE)
+
+        assert converter.convert_field_value_safe(
+            "Users", ["ou_1", "ou_2"], {"Users": 11}
+        ) == [{"id": "ou_1"}, {"id": "ou_2"}]
+        assert converter.convert_field_value_safe(
+            "Files", ["file_1", "file_2"], {"Files": 17}
+        ) == [{"file_token": "file_1"}, {"file_token": "file_2"}]
+        assert converter.convert_field_value_safe(
+            "Links", ["rec_1", "rec_2"], {"Links": 18}
+        ) == ["rec_1", "rec_2"]
+
 
 class TestSimpleConvertValue:
     """简单值转换测试（电子表格模式）"""
@@ -675,6 +710,24 @@ class TestDfToRecords:
             {
                 "Name": [
                     [{"text": "李宁少昊运动户外专卖店", "type": "text"}],
+                ]
+            }
+        )
+
+        records = converter.df_to_records(df, {"Name": 1})
+
+        assert records == [{"fields": {"Name": "李宁少昊运动户外专卖店"}}]
+
+    def test_df_to_records_preserves_multi_segment_text_value(self):
+        """测试多段富文本写入不会被 pandas 空值判断中断"""
+        converter = DataConverter(TargetType.BITABLE)
+        df = pd.DataFrame(
+            {
+                "Name": [
+                    [
+                        {"text": "李宁少昊", "type": "text"},
+                        {"text": "运动户外专卖店", "type": "text"},
+                    ],
                 ]
             }
         )

--- a/utils/excel_reader.py
+++ b/utils/excel_reader.py
@@ -166,7 +166,7 @@ def smart_read_excel(
         raise Exception(error_msg) from e
 
 
-def get_available_engines() -> dict:
+def get_available_engines() -> EngineInfo:
     """
     检测当前环境可用的 Excel 读取引擎
 
@@ -242,7 +242,9 @@ def print_engine_info(verbose: bool = True) -> Optional[str]:
     elif engines["openpyxl"]:
         info = "📖 Excel引擎: OpenPyXL (标准模式)"
     else:
-        info = "⚠️ 警告: 未安装 Excel 引擎，请运行: pip install python-calamine openpyxl"
+        info = (
+            "⚠️ 警告: 未安装 Excel 引擎，请运行: pip install python-calamine openpyxl"
+        )
 
     if verbose:
         print(info)


### PR DESCRIPTION
## 背景

修复 #9：多维表格在使用索引列匹配记录时，远端字段返回值可能是富文本对象列表、日期毫秒时间戳、公式/查找引用包装结构等复杂类型。原逻辑在本地和远端两侧使用了不一致的字符串化方式，导致本应更新的记录无法命中索引，进而被当作新增记录处理。

## 问题归因

- 文本字段写入时通常是普通字符串，但查询记录时可能返回 `[{"text": "...", "type": "text"}]` 这类富文本片段列表。
- 日期字段写入和读取都使用毫秒时间戳，但日期字符串写入侧按本地日期语义生成时间戳；索引归一化如果按 UTC 解释该时间戳，会在 `Asia/Shanghai` 等时区出现跨日偏移。
- 公式/查找引用等字段可能返回 `{type, value}` 包装结构，不能直接 `str()` 后参与 hash。
- `pd.isnull()` / `pd.notnull()` 直接处理 list/dict 会出现歧义，容易在复杂字段写入或预检查阶段中断同步。

## 变更内容

- 为 Bitable 索引匹配增加统一规范化逻辑：
  - 文本/富文本：`[{"text": "...", "type": "text"}]`、`list[str]` 与普通字符串按同一文本值匹配。
  - 日期字段：本地日期字符串与远端毫秒时间戳按同一本地日期语义匹配，覆盖 XTF 写出后读回的 roundtrip 场景。
  - 公式/查找引用包装：支持 `{type, value}` 结构展开后参与索引匹配。
  - 数字、布尔、人员、附件、关联等常见结构增加稳定规范化处理。
- 在 `full`、`incremental`、`overwrite` 三种 Bitable 同步路径中传入字段类型，确保索引构建和本地行匹配使用同一规则。
- 复杂字段空值判断改为统一方法，避免 `pd.isnull()` / `pd.notnull()` 处理 list/dict 时出现歧义。
- 文本字段写入时不再把飞书富文本结构直接转换成 Python 字面量字符串，空富文本不会生成空字符串 hash。
- 增加 issue 场景相关单元测试，覆盖富文本、`list[str]`、日期时间戳、日期本地时区 roundtrip、公式包装、空复杂字段和多值复杂字段。
- 补充少量 Black/Mypy 所需的格式与类型标注收口，确保现有 CI 质量门禁通过。

## 验证

按要求未进行真实飞书运行测试，没有使用真实 token 调用飞书 API。已完成本地静态/单元验证：

- `PYTHONPATH=. python3 -m pytest tests/test_converter.py -q`：57 passed
- `PYTHONPATH=. python3 -m pytest tests/ -q -m "not integration"`：164 passed，本机 requests 依赖版本 warning 不影响结果
- `python3 -m ruff check . --ignore E501,F401`
- `python3 -m black --check .`
- `python3 -m mypy core/ api/ utils/ --ignore-missing-imports`
- `python3 -m py_compile XTF.py core/*.py api/*.py utils/*.py`
- `git diff --check origin/main...HEAD && git diff --check`

已补充本地最小复现验证：多段富文本、多值人员字段、空富文本索引、日期字段写出后读回 roundtrip 均通过。

远端 GitHub Actions 已通过当前 head 的 `Code Quality`、`Test Summary`、Ubuntu/macOS/Windows 全矩阵 Unit Tests。当前 head 为 `f0e8737b6a970be01adda25e889279a836d7441d`。

Closes #9
