### PR TITLE
Add Codex AGENTS routing guidance

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,27 @@
+# .github guardrail card
+
+`.github/` contains GitHub Actions workflows for tests, quality checks, coverage upload, and PyInstaller builds.
+Before editing it, read the target workflow and root `AGENTS.md` command list.
+Keep reading this card when changing CI commands, matrices, artifact names, build packaging, or secrets usage.
+
+## Key files
+
+- `workflows/test.yml`: lint, Black check, MyPy, syntax check, pytest matrix, coverage upload.
+- `workflows/multi-platform-build.yml`: multi-platform builds for `XTF.py` and legacy `lite/` scripts.
+
+## Local invariants
+
+- Root validation commands mirror `test.yml`; update root `AGENTS.md` if CI commands change.
+- Preserve Python 3.10-3.13 and Linux/Windows/macOS coverage unless the PR explains the reduction.
+- Build workflow must continue covering main `XTF` plus `XTF-Sheet` and `XTF-Bitable`.
+- Release zips copy `config.example.yaml` as `config.yaml`; template changes affect packaged defaults.
+
+## Do not
+
+- Do not put real secrets in workflows; use GitHub secrets such as `CODECOV_TOKEN`.
+- Do not skip lint, typecheck, tests, or failure exits without documenting the impact.
+- Do not change artifact retention, platform labels, or names casually.
+
+## Validation
+
+Use root validation commands. Workflow execution itself requires GitHub Actions; local checks only validate the commands they invoke.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# XTF root router
+
+本仓库是 Python CLI 工具 XTF，用于把本地 Excel/CSV 数据同步到飞书 Bitable 或 Sheet。团队通常从仓库根目录启动 Codex，因此本文件是启动期规则、目录地图和按需读取路由器。
+
+## Directory map
+
+| Path | Responsibility | Local AGENTS.md | Read when |
+| --- | --- | --- | --- |
+| `XTF.py` | CLI 入口、日志初始化、配置加载、同步流程编排 | No | 修改命令行入口、运行流程、用户可见输出时 |
+| `core/` | 配置模型、同步引擎、字段转换、读取和高级重试/频控 | Yes | 修改配置、同步模式、选择性同步、字段策略、分块、公式保护时 |
+| `api/` | 飞书认证、HTTP 客户端、Bitable/Sheet API 封装 | Yes | 修改 token、分页、限流、重试、批量写入/删除、range 校验时 |
+| `utils/` | 读取辅助工具和可选 Excel 引擎检测 | Yes | 修改 Excel/CSV 读取能力、引擎回退、文件格式支持时 |
+| `tests/` | pytest 单元测试、fixtures、mock 约定 | Yes | 新增或调整测试、fixtures、coverage 范围、测试标记时 |
+| `docs/` | 架构、配置、同步、字段、Sheet、频控文档 | Yes | 修改文档或需要根据文档确认行为时 |
+| `docs/feishu-openapi-doc/` | 飞书 OpenAPI 外部参考资料，git submodule | Covered by `docs/AGENTS.md` | 查接口资料时；不要在其中直接写本仓库规则 |
+| `lite/` | legacy 独立脚本和旧版发行入口 | Yes | 修改 `XTF_Bitable.py`、`XTF_Sheet.py` 或 legacy 构建产物时 |
+| `.github/` | GitHub Actions 测试、质量检查、多平台 PyInstaller 构建 | Yes | 修改 CI、测试矩阵、artifact、release/build 行为时 |
+| `logs/`, `htmlcov/`, caches | 运行日志、coverage HTML、pytest/ruff/cache 产物 | No | 默认不要修改、提交或依赖这些目录 |
+| `config.example.yaml` | 可提交配置模板 | No | 修改配置字段、默认值、发行包默认配置时 |
+| `config.yaml` | 本地真实配置，gitignored | No | 只用于本地手动运行；不要提交 |
+
+## On-demand read protocol
+
+Before editing files under a directory that has a local `AGENTS.md`, read that file first. If multiple nested `AGENTS.md` files exist on the path to the target file, read them from shallow to deep before making changes.
+
+Subdirectory `AGENTS.md` files are navigation cards, not startup rules. They only contain local invariants, guardrails, and special validation notes. Do not assume they were loaded unless you explicitly read them in the current turn.
+
+## Commands
+
+All commands run from repository root.
+
+Install runtime dependencies, requires network:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+Install test/dev dependencies, requires network:
+
+```bash
+python -m pip install -r requirements-dev.txt
+```
+
+Run unit tests, no external Feishu service required:
+
+```bash
+pytest tests/ -v
+pytest tests/ -v -m "not integration" --tb=short --cov=core --cov=api --cov=utils --cov-report=term
+```
+
+CI quality checks:
+
+```bash
+ruff check . --ignore E501,F401
+black --check .
+mypy core/ api/ utils/ --ignore-missing-imports
+python -m py_compile XTF.py core/*.py api/*.py utils/*.py
+```
+
+Legacy syntax check:
+
+```bash
+python -m py_compile lite/*.py
+```
+
+Run the app manually, requires valid `config.yaml`, Feishu credentials, network, and may write remote data:
+
+```bash
+python XTF.py --target-type bitable --config config.yaml
+python XTF.py --target-type sheet --config config.yaml
+```
+
+Build is defined in `.github/workflows/multi-platform-build.yml`; there is no local build script. CI installs `pyinstaller` and builds `XTF.py`, `lite/XTF_Sheet.py`, and `lite/XTF_Bitable.py`. Local replication requires network for dependencies and platform-specific tooling. There are no migration or codegen commands in this repository.
+
+## Global rules
+
+- Keep architecture boundaries: `XTF.py` coordinates, `core/` owns configuration and sync logic, `api/` owns Feishu HTTP details, `utils/` owns reusable helpers, `tests/` owns validation.
+- Configuration priority must remain CLI arguments > YAML config > intelligent inference > defaults.
+- Treat `overwrite` and `clone` as destructive remote-data modes. Any change touching them must describe deletion risk and validation.
+- Consider both `bitable` and `sheet` targets for shared behavior changes.
+- `config.example.yaml` is the committed template; `config.yaml` is local and ignored.
+- Prefer focused tests near the changed module. Use mocks for HTTP, retry timing, and Feishu responses.
+
+## Do not
+
+- Do not commit real `app_secret`, `app_token`, `spreadsheet_token`, `tenant_access_token`, local `config.yaml`, or logs.
+- Do not hand-edit or commit `logs/`, `htmlcov/`, `.pytest_cache/`, `.ruff_cache/`, `__pycache__/`, `dist/`, `build/`, or other generated/cache output.
+- Do not edit `docs/feishu-openapi-doc/` as normal documentation; it is a submodule reference.
+- Do not weaken validation, lint, typecheck, or test workflow settings without explaining the impact.
+
+## Done criteria
+
+A change is complete when the relevant local navigation card has been read, unrelated dirty files are excluded, the smallest relevant tests have run, broader CI-equivalent checks have run when the blast radius is shared, and any skipped validation is explicitly justified.

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,31 @@
+# api navigation card
+
+`api/` owns Feishu authentication and HTTP wrappers for Bitable and Sheet.
+Before editing it, read the target API module and `docs/CONTROL.md`.
+Keep reading this card when a change touches token handling, pagination, retry, rate limits, batch write/delete, or Sheet ranges.
+
+## Key files
+
+- `auth.py`: `tenant_access_token` acquisition, cache, refresh.
+- `base.py`: `RateLimiter` and `RetryableAPIClient`.
+- `bitable.py`: fields, record search pagination, batch create/update/delete.
+- `sheet.py`: spreadsheet metadata, range read/write/append/clear/style.
+- `tests/test_api_base.py`: covered retry/client behavior.
+
+## Local invariants
+
+- Logs must redact secrets and tokens.
+- Bitable pagination must honor `page_token` and guard against repeated tokens.
+- Batch create should keep idempotency via `client_token`.
+- Sheet operations must validate ranges before read/write/clear/style calls.
+- Retry behavior for 429, 5xx, request exceptions, and known Feishu business codes must stay predictable.
+
+## Do not
+
+- Do not test against real Feishu APIs in unit tests.
+- Do not log full `Authorization`, `app_secret`, `app_token`, or `spreadsheet_token`.
+- Do not hide delete operations behind no-log helper paths.
+
+## Validation
+
+Use root validation commands. For focused base-client changes, start with `pytest tests/test_api_base.py -v`.

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -1,0 +1,30 @@
+# core navigation card
+
+`core/` is the configuration and sync behavior domain for XTF.
+Before editing it, read the target module plus the matching docs under `docs/`.
+Keep reading this card when a change touches sync modes, config validation, conversion, chunking, retry, or Sheet formula protection.
+
+## Key files
+
+- `config.py`: `SyncConfig`, CLI/YAML merge, target inference, validation.
+- `engine.py`: `XTFSyncEngine`, Bitable/Sheet dispatch, `full`/`incremental`/`overwrite`/`clone`.
+- `converter.py`: field type detection, conversion, index building.
+- `reader.py`: Excel/CSV read path used by the CLI.
+- `control.py`: retry and rate-limit strategies.
+
+## Local invariants
+
+- Keep config priority as CLI > YAML > inference > defaults.
+- `selective_sync` remains incompatible with `clone`.
+- `overwrite` and `clone` are destructive remote-data modes; preserve clear logging, batching, and failure semantics.
+- Sheet formula protection depends on Formula and FormattedValue dual reads; do not overwrite protected formula columns.
+- Field strategies stay progressive: `raw`, `base`, `auto`, `intelligence`.
+
+## Do not
+
+- Do not bypass required-field validation, duplicate-column checks, range limits, retry, rate limiting, or chunk splitting.
+- Do not move Feishu HTTP details into `core/`; that belongs in `api/`.
+
+## Validation
+
+Use root validation commands. For focused changes, start with the matching `tests/test_config.py`, `tests/test_converter.py`, `tests/test_reader.py`, or `tests/test_control.py`.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,26 @@
+# docs guardrail card
+
+`docs/` is the user and developer reference for architecture, config, sync, fields, Sheet behavior, and control strategies.
+Before editing it, read `docs/README.md` and the topic document being changed.
+Keep reading this card when updating commands, config fields, Feishu API descriptions, risk warnings, or examples.
+
+## Key files
+
+- `ARCH.md`, `CONFIG.md`, `SYNC.md`, `FIELD_TYPES.md`, `SHEET.md`, `CONTROL.md`.
+- `feishu-openapi-doc/`: git submodule with external Feishu OpenAPI reference.
+
+## Local invariants
+
+- Commands, defaults, CLI flags, config keys, and error codes must match code, CI, or cited OpenAPI docs.
+- Example YAML must stay consistent with `config.example.yaml`.
+- `overwrite`, `clone`, credentials, tokens, rate limits, and formula protection need explicit risk wording.
+
+## Do not
+
+- Do not invent APIs, commands, performance numbers, or Feishu limits.
+- Do not edit `docs/feishu-openapi-doc/` as normal docs; update it only as a submodule when explicitly requested.
+- Do not paste real `config.yaml`, logs, or tokens.
+
+## Validation
+
+Use root validation commands. Documentation-only changes have no dedicated build command in this repository.

--- a/lite/AGENTS.md
+++ b/lite/AGENTS.md
@@ -1,0 +1,26 @@
+# lite navigation card
+
+`lite/` contains legacy standalone scripts kept for compatibility and release artifacts.
+Before editing it, read `lite/README.md` and `.github/workflows/multi-platform-build.yml`.
+Keep reading this card when changing `XTF_Bitable.py`, `XTF_Sheet.py`, legacy CLI behavior, or legacy artifact names.
+
+## Key files
+
+- `XTF_Bitable.py`: standalone legacy Bitable sync script.
+- `XTF_Sheet.py`: standalone legacy Sheet sync script.
+- `README.md`: legacy usage notes.
+
+## Local invariants
+
+- Preserve existing CLI flags, config fields, and standalone execution behavior unless the PR explicitly breaks compatibility.
+- CI still builds `XTF-Sheet` and `XTF-Bitable`; artifact names matter.
+- Security or destructive-sync fixes may need to be mirrored between mainline and both legacy scripts.
+
+## Do not
+
+- Do not add new mainline features here first.
+- Do not remove legacy scripts or change binary names without updating workflow and release notes.
+
+## Validation
+
+Use root validation commands. For focused legacy syntax checks, run `python -m py_compile lite/*.py`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,26 @@
+# tests navigation card
+
+`tests/` contains the pytest suite for config, conversion, reading, retry/rate control, and base HTTP client behavior.
+Before editing it, read `tests/README.md` and `tests/conftest.py`.
+Keep reading this card when adding tests, fixtures, mocks, markers, or coverage expectations.
+
+## Key files
+
+- `conftest.py`: shared configs, DataFrames, temp files.
+- `test_config.py`, `test_converter.py`, `test_reader.py`, `test_control.py`, `test_api_base.py`: module-specific coverage.
+
+## Local invariants
+
+- Test files use `test_*.py`; test names should describe behavior and condition.
+- Reuse existing fixtures before adding new ones.
+- Mock HTTP calls, time sleeps, retries, and Feishu responses.
+- Tests requiring real services must be marked `integration`; default CI excludes them.
+
+## Do not
+
+- Do not depend on real `config.yaml`, network, test order, local logs, or remote Feishu state.
+- Do not use real credentials; keep fake values such as `test_app_secret`.
+
+## Validation
+
+Use root validation commands. For test-only changes, run the touched test file first, then `pytest tests/ -v -m "not integration" --tb=short`.

--- a/utils/AGENTS.md
+++ b/utils/AGENTS.md
@@ -1,0 +1,26 @@
+# utils navigation card
+
+`utils/` contains reusable helpers, currently focused on Excel engine detection and read support.
+Before editing it, read `utils/excel_reader.py`, `core/reader.py`, and `tests/test_reader.py`.
+Keep reading this card when a change affects input file formats, optional reader engines, or fallback behavior.
+
+## Key files
+
+- `excel_reader.py`: Calamine/OpenPyXL helper functions and engine information.
+- `core/reader.py`: primary DataFrame reading path used by the CLI.
+- `tests/test_reader.py`: file-format and edge-case coverage.
+
+## Local invariants
+
+- Preserve Calamine-first, OpenPyXL-fallback behavior when optional dependencies are present.
+- CSV remains experimental; do not present it as equivalent to Excel.
+- Helpers should have no Feishu/network side effects.
+
+## Do not
+
+- Do not import `api/` or `core/engine.py` into utility helpers.
+- Do not swallow file-not-found, unsupported-format, or encoding errors.
+
+## Validation
+
+Use root validation commands. For focused read-path changes, start with `pytest tests/test_reader.py -v`.


### PR DESCRIPTION
## Summary

- Add a root `AGENTS.md` router with the Codex startup model, directory map, on-demand read protocol, and confirmed repository commands.
- Add compact domain navigation cards for `core/`, `api/`, `utils/`, `tests/`, and `lite/`.
- Add guardrail cards for `docs/` and `.github/`, including submodule, secret, CI, and artifact constraints.

## Validation

- `git diff --check`
- `python -m py_compile XTF.py core/*.py api/*.py utils/*.py lite/*.py`

## Notes

- This PR intentionally contains only `AGENTS.md` files.
- Existing local `config.example.yaml` changes were not staged or committed.